### PR TITLE
Fixed issue based on PR comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By using the -h or --help flag user is able to see help information
 
 The program accepts inputs from the user using the -i or --input flag. Acceptable inputs are files and or folders. The program allows for the input for txt and md file extensions.
 
-Currently, the only working Markdown syntax is bold.
+Currently, the only working Markdown syntax is header1 "#".
 
 ### Output
 Output is stored in a current directory in folder named dist


### PR DESCRIPTION
For this Pull Request, I am working on Issue #6  functionality.

I was able to make small changes to allow the ability for the tool to recognize .md files.
Now that the tool is able to find .md files, it is able to read them and create an appropriate .html file.

Finally, this PR also includes functionality for the tool to recognize the bold Markdown syntax (Sample Text), and replicate it into the HTML file with tags.